### PR TITLE
Allow the use of custom value instead of globally defined

### DIFF
--- a/acm-v2.cfndsl.rb
+++ b/acm-v2.cfndsl.rb
@@ -32,7 +32,7 @@ CloudFormation do
 
   Output(:CertificateArn) {
     Value Ref(:Certificate)
-    Export(FnSub("${EnvironmentName}-#{export}-cert-arn"))
+    Export FnJoin('-', [Ref('EnvironmentName'), export, 'cert', 'arn'])
   }
 
 end


### PR DESCRIPTION
Allow the use of custom DnsPrefix instead of the global EnvironmentName variable.